### PR TITLE
Fix crash when current_live_activity_id column is null

### DIFF
--- a/mobile/lib/database/data_manager.dart
+++ b/mobile/lib/database/data_manager.dart
@@ -138,7 +138,7 @@ class DataManager implements Manager {
       );
     }
 
-    return results.first["current_live_activity_id"] as String;
+    return results.first["current_live_activity_id"] as String?;
   }
 
   Future<List<Activity>> getActivities(List<String> ids) async {

--- a/mobile/lib/live_activities_manager.dart
+++ b/mobile/lib/live_activities_manager.dart
@@ -172,14 +172,28 @@ class LiveActivitiesManager implements Manager {
 
     _log.d("Sending update request: ${session.activityId}");
 
-    // Android's live activity notification is rebuilt from scratch on every
-    // update call (unlike iOS, which reads persisted values by key), so all
-    // fields consumed by CustomLiveActivityManager must be resent here.
-    await _liveActivities.updateActivity(id!, {
-      "activity_id": activity.id,
-      "activity_name": activity.name,
-      "session_start_timestamp": session.startTimestamp,
-    });
+    try {
+      // Android's live activity notification is rebuilt from scratch on
+      // every update call (unlike iOS, which reads persisted values by
+      // key), so all fields consumed by CustomLiveActivityManager must be
+      // resent here.
+      await _liveActivities.updateActivity(id!, {
+        "activity_id": activity.id,
+        "activity_name": activity.name,
+        "session_start_timestamp": session.startTimestamp,
+      });
+    } on PlatformException catch (e) {
+      _log.e(e, reason: "Live activity update");
+
+      // The live activity no longer exists on the OS side (e.g. dismissed
+      // by the user, or permission was revoked) — clear the stale ID so
+      // later updates for this session stop retrying against it.
+      await DataManager.get.updateActivity(
+        (ActivityBuilder.fromActivity(
+          activity,
+        )..currentLiveActivityId = null).build,
+      );
+    }
   }
 
   Future<void> _onSessionEndedOrDeleted(Session session) async {

--- a/mobile/lib/live_activities_manager.dart
+++ b/mobile/lib/live_activities_manager.dart
@@ -183,7 +183,11 @@ class LiveActivitiesManager implements Manager {
         "session_start_timestamp": session.startTimestamp,
       });
     } on PlatformException catch (e) {
-      _log.e(e, reason: "Live activity update");
+      if (e.code == "ACTIVITY_ERROR") {
+        _log.d("Live activity not found; not allowed or dismissed by user");
+      } else {
+        _log.e(e, reason: "Live activity update");
+      }
 
       // The live activity no longer exists on the OS side (e.g. dismissed
       // by the user, or permission was revoked) — clear the stale ID so

--- a/mobile/test/database/data_manager_test.dart
+++ b/mobile/test/database/data_manager_test.dart
@@ -576,6 +576,16 @@ void main() {
     expect(liveActivityId, isNull);
   });
 
+  test("currentLiveActivityId returns null if column value is null", () async {
+    when(database.rawQuery(any, any)).thenAnswer(
+      (_) => Future.value([
+        {"current_live_activity_id": null},
+      ]),
+    );
+
+    expect(await DataManager.get.currentLiveActivityId("test-id"), isNull);
+  });
+
   test(
     "currentLiveActivityId returns first ID if multiple are returned",
     () async {

--- a/mobile/test/live_activities_manager_test.dart
+++ b/mobile/test/live_activities_manager_test.dart
@@ -408,6 +408,37 @@ void main() {
         await initManager();
         await emitSessionEvent(.updated);
       });
+      expect(
+        logs.last.contains(
+          "Live activity not found; not allowed or dismissed by user",
+        ),
+        isTrue,
+      );
+
+      final result = verify(managers.dataManager.updateActivity(captureAny));
+      result.called(1);
+      expect((result.captured.first as Activity).currentLiveActivityId, isNull);
+    },
+  );
+
+  test(
+    "On session updated clears the stale ID for an unknown update exception",
+    () async {
+      when(managers.subscriptionManager.isFree).thenReturn(false);
+      when(
+        managers.dataManager.currentLiveActivityId(any),
+      ).thenAnswer((_) => Future.value("live-activity-id"));
+      when(
+        managers.dataManager.activity(any),
+      ).thenAnswer((_) => Future.value(ActivityBuilder("Test").build));
+      when(liveActivities.updateActivity(any, any)).thenAnswer(
+        (_) => throw PlatformException(code: "Test", message: "Test exception"),
+      );
+
+      final logs = await capturePrintStatements(() async {
+        await initManager();
+        await emitSessionEvent(.updated);
+      });
       expect(logs.last.contains("Live activity update"), isTrue);
 
       final result = verify(managers.dataManager.updateActivity(captureAny));

--- a/mobile/test/live_activities_manager_test.dart
+++ b/mobile/test/live_activities_manager_test.dart
@@ -387,6 +387,35 @@ void main() {
     expect(result.captured.last["activity_name"], "Test");
   });
 
+  test(
+    "On session updated clears the stale ID when the live activity no longer exists",
+    () async {
+      when(managers.subscriptionManager.isFree).thenReturn(false);
+      when(
+        managers.dataManager.currentLiveActivityId(any),
+      ).thenAnswer((_) => Future.value("live-activity-id"));
+      when(
+        managers.dataManager.activity(any),
+      ).thenAnswer((_) => Future.value(ActivityBuilder("Test").build));
+      when(liveActivities.updateActivity(any, any)).thenAnswer(
+        (_) => throw PlatformException(
+          code: "ACTIVITY_ERROR",
+          message: "Activity not found",
+        ),
+      );
+
+      final logs = await capturePrintStatements(() async {
+        await initManager();
+        await emitSessionEvent(.updated);
+      });
+      expect(logs.last.contains("Live activity update"), isTrue);
+
+      final result = verify(managers.dataManager.updateActivity(captureAny));
+      result.called(1);
+      expect((result.captured.first as Activity).currentLiveActivityId, isNull);
+    },
+  );
+
   test("On session ended exits early if the user is free", () async {
     when(managers.subscriptionManager.isFree).thenReturn(true);
     await initManager();


### PR DESCRIPTION
## Summary

- Fixes a fatal crash: `type 'Null' is not a subtype of type 'String' in type cast` at `DataManager.currentLiveActivityId` (data_manager.dart:141), called from `LiveActivitiesManager._onSessionUpdated`.
- Fixes a second crash in the same code path: `PlatformException(ACTIVITY_ERROR, Activity not found)` thrown from `LiveActivitiesManager._onSessionUpdated` when the DB's `current_live_activity_id` points at a live activity that no longer exists on the OS side (e.g. dismissed by the user, or Live Activity permission was denied/revoked).
- Still crashing as of v2.0.1 (iOS) — top-priority open issue on the current release.

## Why the crashes happen

### 1. Null cast in `currentLiveActivityId`

`currentLiveActivityId` reads the `current_live_activity_id` column from the `activity` table and cast the result directly `as String`. That column is nullable (an activity legitimately has no live activity ID most of the time — it's only set while a Live Activity is actively running). When the row exists but the column value is `null`, the cast throws instead of returning `null` as the function's own declared return type (`Future<String?>`) already promises.

The caller, `LiveActivitiesManager._onSessionUpdated`, already handles a `null`/empty result correctly via `isEmpty(id)` — so the only change needed is fixing the cast to `as String?`.

### 2. Unhandled `PlatformException` when the live activity was dismissed

Even with a valid, non-null `current_live_activity_id` in the DB, the OS-level Live Activity it points to can stop existing independently of our app state — the user can dismiss it from the Lock Screen/Dynamic Island, or Live Activity permission can be revoked mid-session. In that case `_liveActivities.updateActivity(id, ...)` throws `PlatformException(ACTIVITY_ERROR, "Activity not found")`, which was unhandled.

The fix wraps the call in a `try`/`on PlatformException catch`, logs the exception, and clears the now-stale `currentLiveActivityId` in the DB so subsequent session updates short-circuit at the existing `isEmpty(id)` check instead of repeatedly hitting the same error.

## Reproduction steps

From the Crashlytics stack trace and session logs: this fires during normal app usage whenever a session update occurs for an activity that has no in-progress Live Activity — i.e. any time `LiveActivitiesManager._onSessionUpdated` runs (session start/update/end) for an activity where `current_live_activity_id` is `NULL` in the database. This is a common, not edge-case, path — 30 crash events across 2 users in the sampled window, still occurring on 2.0.1.

## Crashlytics issue

https://console.firebase.google.com/v1/appid/project/activity-log-ed0d0/crashlytics/app/1:369664271784:ios:63e4cb098ece2abe/issues/9727a56a0ee8f1105300936289df9600

## Test plan

- [x] Added `currentLiveActivityId returns null if column value is null` to `data_manager_test.dart`, reproducing the exact crash (verified it fails with the same exception/message/location before the fix, passes after).
- [x] Added `On session updated clears the stale ID when the live activity no longer exists` to `live_activities_manager_test.dart`, reproducing the `ACTIVITY_ERROR` crash and verifying the stale ID is cleared.
- [x] Full `data_manager_test.dart` suite passes (37/37).
- [x] Full `live_activities_manager_test.dart` suite passes (31/31).
- [x] `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
