### PR TITLE
Fix share sheet crash on iOS 26 iPhones (upgrade share_plus, bump Kotlin)

### DIFF
--- a/mobile/android/settings.gradle
+++ b/mobile/android/settings.gradle
@@ -23,7 +23,7 @@ plugins {
     id "com.google.gms.google-services" version "4.3.15" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false
     // END: FlutterFire Configuration
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 
 include ":app"

--- a/mobile/lib/pages/settings_page.dart
+++ b/mobile/lib/pages/settings_page.dart
@@ -334,13 +334,12 @@ class SettingsPageState extends State<SettingsPage> {
 
     setState(onDone);
 
-    try {
-      await Share.shareXFiles([
-        XFile(path, mimeType: mimeType),
-      ], sharePositionOrigin: sharePositionOrigin);
-    } catch (e) {
-      _log.e(e, reason: "Failed to share file");
-    }
+    await SharePlus.instance.share(
+      ShareParams(
+        files: [XFile(path, mimeType: mimeType)],
+        sharePositionOrigin: sharePositionOrigin,
+      ),
+    );
   }
 
   void _startImport() async {

--- a/mobile/lib/pages/settings_page.dart
+++ b/mobile/lib/pages/settings_page.dart
@@ -334,9 +334,13 @@ class SettingsPageState extends State<SettingsPage> {
 
     setState(onDone);
 
-    await Share.shareXFiles([
-      XFile(path, mimeType: mimeType),
-    ], sharePositionOrigin: sharePositionOrigin);
+    try {
+      await Share.shareXFiles([
+        XFile(path, mimeType: mimeType),
+      ], sharePositionOrigin: sharePositionOrigin);
+    } catch (e) {
+      _log.e(e, reason: "Failed to share file");
+    }
   }
 
   void _startImport() async {

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   community_charts_flutter: ^1.0.4            # https://pub.dev/packages/community_charts_flutter
   collection: ^1.19.1                         # https://pub.dev/packages/collection (Dart)
   device_info_plus: ^11.3.0                   # https://pub.dev/packages/device_info_plus (Flutter)
-  share_plus: ^10.1.4                         # https://pub.dev/packages/share_plus (Verified)
+  share_plus: ^12.0.2                         # https://pub.dev/packages/share_plus (Verified)
   file_picker: ^10.0.0                        # https://pub.dev/packages/file_picker (Verified)
   fixnum: ^1.1.1                              # https://pub.dev/packages/fixnum (Dart)
   flutter_email_sender: ^8.0.0                # https://pub.dev/packages/flutter_email_sender


### PR DESCRIPTION
## Summary

- Fixes a fatal crash: `PlatformException(error, sharePositionOrigin: argument must be set, {{0, 188}, {390, 72}} must be non-zero and within coordinate space of source view: {{0, 0}, {372, 100}}, null, null)` at `MethodChannelShare.shareXFiles`, called from `SettingsPageState._shareFile` (export/share flow).
- New in v2.0.0, still open — top-priority open issue on the current release (SIGNAL_FRESH).

## Why the crash happens

This is a known upstream `share_plus` bug. On iOS 26 / Xcode 26, `UIActivityViewController.popoverPresentationController` is non-nil on **iPhones** too (previously only true on iPads), so the plugin's iPad-only coordinate-space validation path now also runs on iPhones — and fails, since the app doesn't need to (and doesn't) pass an iPad-style `sharePositionOrigin` rect for iPhone popover-safe presentation.

## Fix (updated from the original try/catch guard)

This PR started as a defensive `try`/`catch` guard around the share call, since the real fix required a version bump this app couldn't take at the time (see below). It's now a proper upstream fix:

- **Upgraded `share_plus` 10.1.4 → 12.0.2**, which includes the actual fix: "Avoid crash on iOS 26 on iPhones with no sharePositionOrigin param" (`share_plus` 12.0.1, fluttercommunity/plus_plugins#3699). Stayed on the 12.x line rather than the latest 13.3.0, because 13.0.0 bumps the transitive `win32` dependency to `^6.0.1`, which conflicts with `adair-flutter-lib`'s `package_info_plus ^9.0.1` (`win32 ^5.5.3`) — resolving that is a separate, shared-library-wide change out of scope here. 12.0.2 also happens to fix an unrelated add-to-app sharing crash.
- **Bumped the Android Kotlin toolchain 2.1.0 → 2.2.0** in `android/settings.gradle`, since `share_plus` 12.0.0+ requires it (AGP `>=8.12.1` and Gradle `>=8.13` were already satisfied).
- **Removed the defensive `try`/`catch`** added in the first commit — the new `ShareParams.sharePositionOrigin` API docs confirm the parameter is now scoped to iPad/Mac only ("has no effect on other devices"), so the specific failure mode is gone by construction, not just papered over.
- **Migrated off the now-deprecated `Share.shareXFiles`** static API to `SharePlus.instance.share(ShareParams(...))`, since the version bump surfaced a deprecation warning at this exact call site.

## Reproduction steps

Tap "Export" or "Export XLSX" in Settings on an iPhone running iOS 26, which calls the share API with a `sharePositionOrigin` rect computed from the tapped list item's on-screen position. Previously, iOS 26 would validate that rect against a "source view" coordinate space that didn't match what the app computes for iPhone, and throw.

## Verification

- [x] `flutter test` — full suite passes (317/317).
- [x] `flutter build apk --debug` succeeds with Kotlin 2.2.0.
- [x] `pod install` resolves cleanly on iOS with the new native `share_plus` pod version.
- [x] `dart analyze` and `dart format` clean (no more deprecation warnings from the old `Share` API).

## Crashlytics issue

https://console.firebase.google.com/v1/appid/project/activity-log-ed0d0/crashlytics/app/1:369664271784:ios:63e4cb098ece2abe/issues/4890024e2f2e7200d931ceba70215bfd

🤖 Generated with [Claude Code](https://claude.com/claude-code)