### PR TITLE
Await schema execution during database create/upgrade

### DIFF
--- a/mobile/lib/database/sqlite_open_helper.dart
+++ b/mobile/lib/database/sqlite_open_helper.dart
@@ -92,24 +92,28 @@ class SQLiteOpenHelper {
     );
   }
 
-  static void _onCreate(Database db, int version) {
+  static Future<void> _onCreate(Database db, int version) async {
     for (var schema in _schema) {
-      _executeSchema(db, schema);
+      await _executeSchema(db, schema);
     }
   }
 
-  static void _onUpgrade(Database db, int oldVersion, int newVersion) {
+  static Future<void> _onUpgrade(
+    Database db,
+    int oldVersion,
+    int newVersion,
+  ) async {
     for (int version = oldVersion; version < newVersion; ++version) {
       if (version >= _schema.length) {
         throw ArgumentError("Invalid database version: $newVersion");
       }
-      _executeSchema(db, _schema[version]);
+      await _executeSchema(db, _schema[version]);
     }
   }
 
-  static void _executeSchema(Database db, List<String> schema) {
+  static Future<void> _executeSchema(Database db, List<String> schema) async {
     for (var query in schema) {
-      db.execute(query);
+      await db.execute(query);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Fixes a fatal crash: `DatabaseException(... "no such table: session" ...) sql 'ALTER TABLE session ADD COLUMN is_banked BOOLEAN DEFAULT false'` at `SqfliteDatabaseMixin.txnSynchronized`, occurring during database creation.
- 100% of crash events happen within the first second of a user's session (SIGNAL_EARLY) — i.e. on fresh app launch, during database creation.

## Why the crash happens

`SQLiteOpenHelper._executeSchema` looped over each SQL statement and called `db.execute(query)` **without awaiting it**:

```dart
static void _executeSchema(Database db, List<String> schema) {
  for (var query in schema) {
    db.execute(query);   // fire-and-forget
  }
}
```

`_onCreate` likewise looped over every schema version (0 through 5) calling `_executeSchema` without awaiting each one. On a fresh install, schema version 0 creates the `activity` and `session` tables, and schema version 1 runs `ALTER TABLE session ADD COLUMN is_banked`. Because none of these calls were awaited, there was no guarantee the `CREATE TABLE session` statement had actually finished executing on the platform side before the `ALTER TABLE session` statement was dispatched — letting the `ALTER TABLE` race ahead and fail with "no such table: session".

## Fix

Made `_onCreate`, `_onUpgrade`, and `_executeSchema` all `async` and `await` each step, so schema statements run strictly in order — both within a schema version's list of statements and across versions. `sqflite`'s `OnDatabaseCreateFn`/`OnDatabaseVersionChangeFn` callback types are already declared as `FutureOr<void> Function(...)`, so this required no changes to `SQLiteOpenHelper.open()`'s call to `openDatabase(...)`.

## Reproduction steps

Fresh install / first launch, before any database exists. `openDatabase` triggers `_onCreate`, which runs all 6 schema versions in one pass to build the current (v6) schema from scratch — this is exactly the code path where the unawaited race could occur.

## Possible side effects

`openDatabase()` will now genuinely wait for all schema statements to finish before resolving, whereas previously it could resolve before they completed. This is strictly safer (matches what callers already assumed), so it shouldn't change any other behavior — see also the crashlytics-triage run notes.

## Test coverage note

No existing test file covers `SQLiteOpenHelper`, and reproducing this specific race reliably in a unit test would require a real SQLite backend (e.g. `sqflite_common_ffi`) plus new test infrastructure — a disproportionate scope expansion for this fix. Verified instead via `dart analyze` (clean) and the full `test/database/` suite (57/57 passing, unmodified).

## Crashlytics issue

https://console.firebase.google.com/v1/appid/project/activity-log-ed0d0/crashlytics/app/1:369664271784:ios:63e4cb098ece2abe/issues/a1cfe2f825475ff691ab97af629ee437

## Test plan

- [x] `dart analyze` clean.
- [x] `dart format` clean.
- [x] Full `test/database/` suite passes (57/57) unmodified.
- [ ] No new automated test added (see note above) — manual fresh-install verification recommended before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)